### PR TITLE
Additional FluxOS Error Checks

### DIFF
--- a/flux_node_viewer.sh
+++ b/flux_node_viewer.sh
@@ -861,7 +861,7 @@ function check_benchmark_log(){
 #check Flux Error file
 function check_flux_log(){
   if [[ -f $FLUX_LOG_DIR ]]; then
-    flux_log=$(tail -200 $FLUX_LOG_DIR | egrep -a -wi "Unable to detect Flux IP|Daemon not yet|Flux geolocation service is awaiting|Connection timed out while searching for the gateway|Node hardware requirements not met|below new|Syncthing is not" | tac | head)
+    flux_log=$(tail -200 $FLUX_LOG_DIR | egrep -a -wi "Flux IP detection failed|My Flux|communication is limited|Unable to detect Flux IP|Daemon not yet|Flux geolocation service is awaiting|Connection timed out while searching for the gateway|Node hardware requirements not met|below new|Syncthing is not|Error getting publicIp from FluxBench" | tac | head)
     if [[ $flux_log == "" ]]; then
       flux_log="${GREEN_ARROW}   No common flux errors logged"
     fi
@@ -873,12 +873,12 @@ function check_flux_log(){
 #check node external IP address and compare it to device IP address
 function check_ip(){
   local_device=$(ip addr | grep 'BROADCAST,MULTICAST,UP,LOWER_UP' | awk 'NR==1 {print $2}')
-  WANIP=$(curl --silent -m 15 https://api.ipify.org | tr -dc '[:alnum:].')
+  WANIP=$(curl --silent -m 20 https://api.ipify.org | tr -dc '[:alnum:].')
   if [[ "$WANIP" == "" ]]; then
-    WANIP=$(curl --silent -m 15 https://ipv4bot.whatismyipaddress.com | tr -dc '[:alnum:].')
+    WANIP=$(curl --silent -m 20 https://ipv4bot.whatismyipaddress.com | tr -dc '[:alnum:].')
   fi
   if [[ "$WANIP" == "" ]]; then
-    WANIP=$(curl --silent -m 15 https://checkip.amazonaws.com | tr -dc '[:alnum:].')
+    WANIP=$(curl --silent -m 20 https://checkip.amazonaws.com | tr -dc '[:alnum:].')
   fi
 
   local_device_ip=$(ip a list $local_device | grep -o $WANIP)
@@ -945,14 +945,16 @@ function check_port_info()
 # function to check flux ports are open to external world
 # Only checks Flux UI port and Flux API Port at this time
 function check_external_ports(){
-  if [[ -n $ui_port && -n $api_port ]]; then
+  if [[ -n $ui_port && -n $api_port]]; then
+    echo -e "${BLUE} checking gui port${NC}"
     checkPort=$(curl --silent --max-time 20 --data "remoteAddress=$WANIP&portNumber=$ui_port" $PORT_CHECK_URL | grep 'open on')
     if [[ -z $checkPort ]]; then
       external_flux_ui_port="${RED_ARROW}   Flux UI Port $ui_port is ${RED}closed${NC} - please check your network settings"
     else
       external_flux_ui_port="${GREEN_ARROW}   Flux UI Port $ui_port is ${GREEN}open${NC}"
     fi
-
+    sleep 1
+    echo -e "${BLUE} checking api port${NC}"
     checkPort=$(curl --silent --max-time 20 --data "remoteAddress=$WANIP&portNumber=$api_port" $PORT_CHECK_URL | grep 'open on')
     if [[ -z $checkPort ]]; then
       external_flux_api_port="${RED_ARROW}   Flux API Port $api_port is ${RED}closed${NC} - please check your network settings"
@@ -960,7 +962,8 @@ function check_external_ports(){
     else
       external_flux_api_port="${GREEN_ARROW}   Flux API Port $api_port is ${GREEN}open${NC}"
     fi
-
+    sleep 1
+    echo -e "${BLUE} checking syncthing port${NC}"
     checkPort=$(curl --silent --max-time 20 --data "remoteAddress=$WANIP&portNumber=$syncthing_port" $PORT_CHECK_URL | grep 'open on')
     if [[ -z $checkPort ]]; then
       external_syncthing_port="${RED_ARROW}   Syncthing Port $syncthing_port is ${RED}closed${NC} - please check your network settings"
@@ -968,7 +971,6 @@ function check_external_ports(){
     else
       external_syncthing_port="${GREEN_ARROW}   Syncthing Port $syncthing_port is ${GREEN}open${NC}"
     fi
-
   else
     external_flux_ui_port="${RED_ARROW}   Flux UI Port is ${RED}NOT LISTENING${NC} - please check FluxOS Service"
     external_flux_api_port="${RED_ARROW}   Flux API Port is ${RED}NOT LISTENING${NC} - please check FluxOS Service"
@@ -1001,7 +1003,7 @@ function check_upnp(){
 function check_version(){
   ## grab current version requirements from the flux api and compare to current node version
   #flux_required_version=$(curl -sS --max-time 5 https://api.runonflux.io/flux/version | jq -r '.data')
-  flux_required_version=$(curl -sS --max-time 5 https://raw.githubusercontent.com/RunOnFlux/flux/master/package.json | jq -r '.version')
+  flux_required_version=$(curl -sS --max-time 20 https://raw.githubusercontent.com/RunOnFlux/flux/master/package.json | jq -r '.version')
   if [[ "$flux_required_version" == "$flux_node_version" ]]; then
     flux_node_version_check="${GREEN_ARROW}   You have the current FluxOS version ${GREEN}$flux_node_version${NC}"
   else
@@ -1011,7 +1013,7 @@ function check_version(){
 
 #checks the current flux bench version and compares to local
 function check_flux_bench_version(){
-  flux_bench_required_version=$(curl -s -m 5 $FLUX_BENCH_CHEKC_URL | grep -o '[0-9].[0-9].[0-9]' | head -n1)
+  flux_bench_required_version=$(curl -s -m 20 $FLUX_BENCH_CHEKC_URL | grep -o '[0-9].[0-9].[0-9]' | head -n1)
   flux_bench_current_version=$(dpkg -l fluxbench | grep -w fluxbench | awk '{print $3}')
 
   if [[ $flux_bench_required_version != $flux_bench_current_version ]]; then
@@ -1021,7 +1023,7 @@ function check_flux_bench_version(){
 
 #checks the current released daemon version and compares to local
 function check_flux_daemon_version(){
-  flux_daemon_required_version=$(curl -s -m 5 $FLUX_DAEMON_CHECK_URL | grep -o '[0-9].[0-9].[0-9]' | head -n1)
+  flux_daemon_required_version=$(curl -s -m 20 $FLUX_DAEMON_CHECK_URL | grep -o '[0-9].[0-9].[0-9]' | head -n1)
   flux_daemon_current_version=$(dpkg -l flux | grep -w flux | awk '{print $3}')
   if [[ $flux_daemon_required_version != $flux_daemon_current_version ]]; then
     flux_daemon_version_check="${RED_ARROW}   You do not have the current version ${SEA}$flux_daemon_required_version${NC} - your local version is ${RED}$flux_daemon_current_version${NC}"
@@ -1030,7 +1032,7 @@ function check_flux_daemon_version(){
 
 # grab current node counts from https://api.runonflux.io/daemon/getzelnodecount
 function check_total_nodes(){
-  local nodeInfo=$(curl -sS --max-time 5 https://api.runonflux.io/daemon/getzelnodecount | jq -r '.data')
+  local nodeInfo=$(curl -sS --max-time 20 https://api.runonflux.io/daemon/getzelnodecount | jq -r '.data')
   total_nodes=$(jq -r '.total' <<<"$nodeInfo" 2>/dev/null)
   cumulus_nodes=$(jq -r '."cumulus-enabled"' <<<"$nodeInfo" 2>/dev/null)
   nimbus_nodes=$(jq -r '."nimbus-enabled"' <<<"$nodeInfo" 2>/dev/null)
@@ -1039,14 +1041,14 @@ function check_total_nodes(){
 
 # check current flux price
 function check_flux_price(){
-  local currencyInfo=$(curl -sS --max-time 5 https://explorer.runonflux.io/api/currency | jq -r '.data' | jq -r '.rate')
+  local currencyInfo=$(curl -sS --max-time 20 https://explorer.runonflux.io/api/currency | jq -r '.data' | jq -r '.rate')
   flux_price=$(printf "%.3f" $currencyInfo)
 }
 
 # check flux DoS List
 function check_flux_dos_list(){
   get_flux_node_info
-  local dosList=$(curl -sS --max-time 5 https://api.runonflux.io/daemon/getdoslist | jq .[] | grep "$flux_node_collateral" -A5 -B1)
+  local dosList=$(curl -sS --max-time 20 https://api.runonflux.io/daemon/getdoslist | jq .[] | grep "$flux_node_collateral" -A5 -B1)
 
   #if node collateral in the DoS list then show number of blocks left
   if [[ -n "$dosList" ]]; then
@@ -1060,7 +1062,7 @@ function check_flux_dos_list(){
 #check user_kda_address in the user config file
 function check_kda_address(){
   LANIP=$(hostname -I | awk '{print $1}')
-  node_kda_address=$(curl -sS --max-time 5 http://$LANIP:$api_port/flux/kadena 2>/dev/null | jq -r '.data' 2>/dev/null)
+  node_kda_address=$(curl -sS --max-time 20 http://$LANIP:$api_port/flux/kadena 2>/dev/null | jq -r '.data' 2>/dev/null)
   user_kda_address=$(grep -w kadena ~/$FLUX_DIR/config/userconfig.js 2>/dev/null | awk -F"'" '/1/ {print $2}' 2>/dev/null)
 
   while true; do
@@ -1214,7 +1216,7 @@ function node_os_update(){
 function get_flux_uptime(){
   #curl local node IP's API port for uptime -s (silent) -S(show error)
   #converts seconds to minutes .. d/h/m/s will come at some point 
-  local get_uptime=$(curl -sS --max-time 5 "http://$LANIP:$api_port/flux/uptime" 2>&1 | jq -r '.data')
+  local get_uptime=$(curl -sS --max-time 20 "http://$LANIP:$api_port/flux/uptime" 2>&1 | jq -r '.data')
   flux_uptime=$(bc <<< "$get_uptime / 60" | awk '{print $1 " mins"}')
 
   if [[ $flux_uptime == "" ]]; then
@@ -1224,10 +1226,10 @@ function get_flux_uptime(){
 
 # Get api network blockheight
 function check_current_blockheight(){
-  local api_current_height=$(curl -sS --max-time 5 "https://api.runonflux.io/daemon/getblockcount" 2>&1 | jq -r '.data')
+  local api_current_height=$(curl -sS --max-time 20 "https://api.runonflux.io/daemon/getblockcount" 2>&1 | jq -r '.data')
   
   if [[ api_current_height == "" ]]; then
-    api_current_height=$(curl -sk -m 5 https://explorer.runonflux.io/api/status?q=getInfo getinfo 2>/dev/null | jq '.info.blocks' 2> /dev/null)
+    api_current_height=$(curl -sk -m 20 https://explorer.runonflux.io/api/status?q=getInfo getinfo 2>/dev/null | jq '.info.blocks' 2> /dev/null)
   fi
 
   if [[ $flux_daemon_block_height == "" ]]; then

--- a/flux_node_viewer.sh
+++ b/flux_node_viewer.sh
@@ -946,7 +946,7 @@ function check_port_info()
 # Only checks Flux UI port and Flux API Port at this time
 function check_external_ports(){
   if [[ -n $ui_port && -n $api_port ]]; then
-    echo -e "${BLUE} checking gui port ... ${NC}"
+    echo -e "${BLUE}   checking gui port ... ${NC}"
     checkPort=$(curl --silent --max-time 20 --data "remoteAddress=$WANIP&portNumber=$ui_port" $PORT_CHECK_URL | grep 'open on')
     if [[ -z $checkPort ]]; then
       external_flux_ui_port="${RED_ARROW}   Flux UI Port $ui_port is ${RED}closed${NC} - please check your network settings"
@@ -954,7 +954,7 @@ function check_external_ports(){
       external_flux_ui_port="${GREEN_ARROW}   Flux UI Port $ui_port is ${GREEN}open${NC}"
     fi
     sleep 1
-    echo -e "${BLUE} checking api port ... ${NC}"
+    echo -e "${BLUE}   checking api port ... ${NC}"
     checkPort=$(curl --silent --max-time 20 --data "remoteAddress=$WANIP&portNumber=$api_port" $PORT_CHECK_URL | grep 'open on')
     if [[ -z $checkPort ]]; then
       external_flux_api_port="${RED_ARROW}   Flux API Port $api_port is ${RED}closed${NC} - please check your network settings"
@@ -963,7 +963,7 @@ function check_external_ports(){
       external_flux_api_port="${GREEN_ARROW}   Flux API Port $api_port is ${GREEN}open${NC}"
     fi
     sleep 1
-    echo -e "${BLUE} checking syncthing port ... ${NC}"
+    echo -e "${BLUE}   checking syncthing port ... ${NC}"
     checkPort=$(curl --silent --max-time 20 --data "remoteAddress=$WANIP&portNumber=$syncthing_port" $PORT_CHECK_URL | grep 'open on')
     if [[ -z $checkPort ]]; then
       external_syncthing_port="${RED_ARROW}   Syncthing Port $syncthing_port is ${RED}closed${NC} - please check your network settings"

--- a/flux_node_viewer.sh
+++ b/flux_node_viewer.sh
@@ -873,12 +873,12 @@ function check_flux_log(){
 #check node external IP address and compare it to device IP address
 function check_ip(){
   local_device=$(ip addr | grep 'BROADCAST,MULTICAST,UP,LOWER_UP' | awk 'NR==1 {print $2}')
-  WANIP=$(curl --silent -m 20 https://api.ipify.org | tr -dc '[:alnum:].')
+  WANIP=$(curl --silent --max-time 20 https://api.ipify.org | tr -dc '[:alnum:].')
   if [[ "$WANIP" == "" ]]; then
-    WANIP=$(curl --silent -m 20 https://ipv4bot.whatismyipaddress.com | tr -dc '[:alnum:].')
+    WANIP=$(curl --silent --max-time 20 https://ipv4bot.whatismyipaddress.com | tr -dc '[:alnum:].')
   fi
   if [[ "$WANIP" == "" ]]; then
-    WANIP=$(curl --silent -m 20 https://checkip.amazonaws.com | tr -dc '[:alnum:].')
+    WANIP=$(curl --silent --max-time 20 https://checkip.amazonaws.com | tr -dc '[:alnum:].')
   fi
 
   local_device_ip=$(ip a list $local_device | grep -o $WANIP)
@@ -945,8 +945,8 @@ function check_port_info()
 # function to check flux ports are open to external world
 # Only checks Flux UI port and Flux API Port at this time
 function check_external_ports(){
-  if [[ -n $ui_port && -n $api_port]]; then
-    echo -e "${BLUE} checking gui port${NC}"
+  if [[ -n $ui_port && -n $api_port ]]; then
+    echo -e "${BLUE} checking gui port ... ${NC}"
     checkPort=$(curl --silent --max-time 20 --data "remoteAddress=$WANIP&portNumber=$ui_port" $PORT_CHECK_URL | grep 'open on')
     if [[ -z $checkPort ]]; then
       external_flux_ui_port="${RED_ARROW}   Flux UI Port $ui_port is ${RED}closed${NC} - please check your network settings"
@@ -954,7 +954,7 @@ function check_external_ports(){
       external_flux_ui_port="${GREEN_ARROW}   Flux UI Port $ui_port is ${GREEN}open${NC}"
     fi
     sleep 1
-    echo -e "${BLUE} checking api port${NC}"
+    echo -e "${BLUE} checking api port ... ${NC}"
     checkPort=$(curl --silent --max-time 20 --data "remoteAddress=$WANIP&portNumber=$api_port" $PORT_CHECK_URL | grep 'open on')
     if [[ -z $checkPort ]]; then
       external_flux_api_port="${RED_ARROW}   Flux API Port $api_port is ${RED}closed${NC} - please check your network settings"
@@ -963,7 +963,7 @@ function check_external_ports(){
       external_flux_api_port="${GREEN_ARROW}   Flux API Port $api_port is ${GREEN}open${NC}"
     fi
     sleep 1
-    echo -e "${BLUE} checking syncthing port${NC}"
+    echo -e "${BLUE} checking syncthing port ... ${NC}"
     checkPort=$(curl --silent --max-time 20 --data "remoteAddress=$WANIP&portNumber=$syncthing_port" $PORT_CHECK_URL | grep 'open on')
     if [[ -z $checkPort ]]; then
       external_syncthing_port="${RED_ARROW}   Syncthing Port $syncthing_port is ${RED}closed${NC} - please check your network settings"
@@ -1002,7 +1002,6 @@ function check_upnp(){
 
 function check_version(){
   ## grab current version requirements from the flux api and compare to current node version
-  #flux_required_version=$(curl -sS --max-time 5 https://api.runonflux.io/flux/version | jq -r '.data')
   flux_required_version=$(curl -sS --max-time 20 https://raw.githubusercontent.com/RunOnFlux/flux/master/package.json | jq -r '.version')
   if [[ "$flux_required_version" == "$flux_node_version" ]]; then
     flux_node_version_check="${GREEN_ARROW}   You have the current FluxOS version ${GREEN}$flux_node_version${NC}"
@@ -1013,7 +1012,7 @@ function check_version(){
 
 #checks the current flux bench version and compares to local
 function check_flux_bench_version(){
-  flux_bench_required_version=$(curl -s -m 20 $FLUX_BENCH_CHEKC_URL | grep -o '[0-9].[0-9].[0-9]' | head -n1)
+  flux_bench_required_version=$(curl -s --max-time 20 $FLUX_BENCH_CHEKC_URL | grep -o '[0-9].[0-9].[0-9]' | head -n1)
   flux_bench_current_version=$(dpkg -l fluxbench | grep -w fluxbench | awk '{print $3}')
 
   if [[ $flux_bench_required_version != $flux_bench_current_version ]]; then
@@ -1023,7 +1022,7 @@ function check_flux_bench_version(){
 
 #checks the current released daemon version and compares to local
 function check_flux_daemon_version(){
-  flux_daemon_required_version=$(curl -s -m 20 $FLUX_DAEMON_CHECK_URL | grep -o '[0-9].[0-9].[0-9]' | head -n1)
+  flux_daemon_required_version=$(curl -s --max-time 20 $FLUX_DAEMON_CHECK_URL | grep -o '[0-9].[0-9].[0-9]' | head -n1)
   flux_daemon_current_version=$(dpkg -l flux | grep -w flux | awk '{print $3}')
   if [[ $flux_daemon_required_version != $flux_daemon_current_version ]]; then
     flux_daemon_version_check="${RED_ARROW}   You do not have the current version ${SEA}$flux_daemon_required_version${NC} - your local version is ${RED}$flux_daemon_current_version${NC}"
@@ -1229,7 +1228,7 @@ function check_current_blockheight(){
   local api_current_height=$(curl -sS --max-time 20 "https://api.runonflux.io/daemon/getblockcount" 2>&1 | jq -r '.data')
   
   if [[ api_current_height == "" ]]; then
-    api_current_height=$(curl -sk -m 20 https://explorer.runonflux.io/api/status?q=getInfo getinfo 2>/dev/null | jq '.info.blocks' 2> /dev/null)
+    api_current_height=$(curl -sk --max-time 20 https://explorer.runonflux.io/api/status?q=getInfo getinfo 2>/dev/null | jq '.info.blocks' 2> /dev/null)
   fi
 
   if [[ $flux_daemon_block_height == "" ]]; then


### PR DESCRIPTION
Add additional error log checking
- Checks for flux availability errors and other misc port issues
- Extends all curl timeouts to 20 seconds
- Add 1 second sleep between port check calls
- Log port checking status to display
